### PR TITLE
Ignore whitespace when viewing diff of a branch

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -25,6 +25,7 @@
 		{
 			"matches" : [
 				"https://bitbucket.org/*/commits/*",
+				"https://bitbucket.org/*/branch/*",
 				"https://bitbucket.org/*/pull-request/*/*",
 				"https://bitbucket.org/*/pull-requests/*/*"
 			],

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -24,8 +24,8 @@
 	"content_scripts" : [
 		{
 			"matches" : [
-				"https://bitbucket.org/*/commits/*",
 				"https://bitbucket.org/*/branch/*",
+				"https://bitbucket.org/*/commits/*",
 				"https://bitbucket.org/*/pull-request/*/*",
 				"https://bitbucket.org/*/pull-requests/*/*"
 			],


### PR DESCRIPTION
Fixes #8 which just needed to activate the extension on BitBucket's branches url regex (add to manifest)
